### PR TITLE
#150761581 add route to get a single recipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,12 +29,14 @@ A RESTful API built for users to share their awesome and exciting recipes ideas 
   - Deletes a recipe
 - **`GET` /recipes**
   - Get all recipes
+- **`GET` /recipes/:id**
+  - Get a single recipe
 - **`POST` /recipes/:id/reviews**
   - Post new review for a recipe
 - **`POST` /recipes/:id/favorite**
   - Favorite a recipe
 - **`POST` /recipes/:id/vote-:dir**
-  - Vote a recipe in `dir` {up or down}
+  - Vote on a recipe `dir`: {up or down}
 
 ### USERS
 

--- a/server/controllers/recipes/getSingleRecipe.js
+++ b/server/controllers/recipes/getSingleRecipe.js
@@ -1,0 +1,17 @@
+import { Recipe, Review, User } from '../../models/index';
+import systemErrorHandler from '../../helpers/systemErrorHandler';
+
+const reviewRecipe = (req, res, next) => {
+  const { id } = req.params;
+
+  Recipe.findById(id, {
+    include: [
+      { model: Review, as: 'reviews' },
+      { model: User, attributes: ['id', 'username', 'fullname'] }
+    ]
+  })
+    .then(recipe => res.status(200).send({ recipe, message: 'success' }))
+    .catch(error => systemErrorHandler(error, next));
+};
+
+export default reviewRecipe;

--- a/server/controllers/recipes/index.js
+++ b/server/controllers/recipes/index.js
@@ -5,6 +5,7 @@ import deleteRecipe from './deleteRecipe';
 import voteRecipe from './voteRecipe';
 import favoriteRecipe from './favoriteRecipe';
 import reviewRecipe from './reviewRecipe';
+import getSingleRecipe from './getSingleRecipe';
 
 const recipesController = {
   getAllRecipe,
@@ -13,7 +14,8 @@ const recipesController = {
   deleteRecipe,
   voteRecipe,
   favoriteRecipe,
-  reviewRecipe
+  reviewRecipe,
+  getSingleRecipe
 };
 
 

--- a/server/routes/recipe.js
+++ b/server/routes/recipe.js
@@ -21,6 +21,7 @@ router.post('/', validateAddRecipe, recipesController.createRecipe);
 // checks if the recipe to be accessed exist
 router.use('/:id', doesRecipeExist);
 
+router.get('/:id', recipesController.getSingleRecipe);
 router.put('/:id', recipesController.updateRecipe);
 router.delete('/:id', recipesController.deleteRecipe);
 

--- a/server/test/test.js
+++ b/server/test/test.js
@@ -482,6 +482,59 @@ describe('API Integration Tests', () => {
     });
   });
 
+  describe('Get a single recipe', () => {
+    // no token
+    // invalid token
+    // recipe doesn't exist
+    // everything good
+
+    it('return 400 if token is not present', (done) => {
+      request.get(`${recipesUrl}/${recipeId}`)
+        .end((err, res) => {
+          expect(res.status).to.equal(400);
+          expect(res.body.message).to.equal('user authorization token required');
+          done();
+        });
+    });
+
+    it('return 403 for invalid user token used', (done) => {
+      request.get(`${recipesUrl}/${recipeId}`)
+        .send({ token: invalidToken })
+        .end((err, res) => {
+          expect(res.status).to.equal(403);
+          expect(res.body.message).to.equal('invalid user authorization token');
+          done();
+        });
+    });
+
+    // if recipe doesnt exist => 404
+    it('return 404 if recipe is not found', (done) => {
+      request.get(`${recipesUrl}/15`)
+        .send({ token: userToken1 })
+        .end((err, res) => {
+          expect(res.status).to.equal(404);
+          expect(res.body.message).to.equal('Recipe not found');
+          done();
+        });
+    });
+
+    it('return 200 for successfully getting all recipes', (done) => {
+      request.get(`${recipesUrl}/${recipeId}`)
+        .send({ token: userToken1 })
+        .end((err, res) => {
+          expect(res.status).to.equal(200);
+          expect(res.body.message).to.equal('success');
+          expect(res.body.recipe.name).to.equal('Fried Rice');
+          expect(res.body.recipe.User.id).to.equal(1);
+          expect(res.body.recipe.img_url).to.equal('http://www.africanbites.com/wp-content/uploads/2014/05/IMG_9677-2-1-150x150.jpg');
+          expect(res.body.recipe.downVoteCount).to.equal(0);
+          expect(res.body.recipe.upVoteCount).to.equal(1);
+          expect(res.body.recipe.viewCount).to.equal(0);
+          done();
+        });
+    });
+  });
+
   describe('Get all recipes', () => {
     // no token
     // invalid token


### PR DESCRIPTION
#### What does this PR do?
Adds a route that enables users to get the details of just a single recipes

#### How should this be manually tested?
In postman, make a `get` request to the endpoint: `/recipes/:id`, where id is the recipe's id.

#### What are the relevant pivotal tracker stories?
#150761581
